### PR TITLE
Fix runtime error for missing subparsers

### DIFF
--- a/datargs/compat/__init__.py
+++ b/datargs/compat/__init__.py
@@ -99,7 +99,9 @@ class RecordClass(Generic[FieldType]):
 
     @property
     def datargs_params(self) -> DatargsParams:
-        return getattr(self.cls, "__datargs_params__", DatargsParams())
+        if not hasattr(self.cls, "__datargs_params__"):
+            self.cls.__datargs_params__ = DatargsParams()
+        return self.cls.__datargs_params__
 
     @property
     def parser_params(self):

--- a/datargs/compat/__init__.py
+++ b/datargs/compat/__init__.py
@@ -17,6 +17,13 @@ class DatargsParams:
     sub_commands: dict = dataclasses.field(default_factory=dict)
     name: str = None
 
+    def __post_init__(self, *args, **kwargs):
+        for key, value in (
+            ("required", True),
+            ("dest", "__datargs_dest__"),
+        ):
+            self.sub_commands.setdefault(key, value)
+
 
 class RecordField(Generic[FieldType]):
     """
@@ -99,9 +106,7 @@ class RecordClass(Generic[FieldType]):
 
     @property
     def datargs_params(self) -> DatargsParams:
-        if not hasattr(self.cls, "__datargs_params__"):
-            self.cls.__datargs_params__ = DatargsParams()
-        return self.cls.__datargs_params__
+        return getattr(self.cls, "__datargs_params__", DatargsParams())
 
     @property
     def parser_params(self):

--- a/datargs/make.py
+++ b/datargs/make.py
@@ -376,16 +376,6 @@ def add_subparsers(
 ):
     # noinspection PyArgumentList
 
-    sub_commands_params = top_class.sub_commands_params
-
-    # Mark subparsers as required by default
-    if "required" not in sub_commands_params:
-        sub_commands_params["required"] = True
-
-    # `required=True` results in a runtime error if `dest` is not set
-    if "dest" not in sub_commands_params:
-        sub_commands_params["dest"] = f"{sub_parsers_field.name} (positional)"
-
     subparsers = cast(
         DatargsSubparsers,
         parser.add_subparsers(

--- a/datargs/make.py
+++ b/datargs/make.py
@@ -333,6 +333,10 @@ class DatargsSubparsers(_SubParsersAction):
         new_ns = Namespace()
         name, *_ = values
         super().__call__(parser, new_ns, values)
+
+        if hasattr(new_ns, self.dest):
+            delattr(new_ns, self.dest)
+
         setattr(namespace, self.__name, self._command_type_map[name](**vars(new_ns)))
 
 
@@ -371,6 +375,17 @@ def add_subparsers(
     sub_parser_classes: Sequence[type],
 ):
     # noinspection PyArgumentList
+
+    sub_commands_params = top_class.sub_commands_params
+
+    # Mark subparsers as required by default
+    if "required" not in sub_commands_params:
+        sub_commands_params["required"] = True
+
+    # `required=True` results in a runtime error if `dest` is not set
+    if "dest" not in sub_commands_params:
+        sub_commands_params["dest"] = f"{sub_parsers_field.name} (positional)"
+
     subparsers = cast(
         DatargsSubparsers,
         parser.add_subparsers(

--- a/tests/test_subcommands.py
+++ b/tests/test_subcommands.py
@@ -59,6 +59,11 @@ def test_subcommands():
     assert result.action.verbose
     assert not result.verbose
 
+    # When a required argument is missing, argparse should print an error and trigger a
+    # system exit
+    with raises(SystemExit):
+        parse(Pip, [])
+
 
 def test_union_no_dataclass():
     @dataclass


### PR DESCRIPTION
Hi!

This patch marks subparsers as required by default.

The issue I was seeing is with simple code that looks like this:
```python
import dataclasses
from typing import Union

import datargs


@dataclasses.dataclass
class A:
    x: int


@dataclasses.dataclass
class B:
    y: int

@dataclasses.dataclass
class Args:
    subcommand: Union[A, B]


print(datargs.parse(Args))
```

which, when run without arguments, results in a runtime error in the master branch:
```
> python test.py
Traceback (most recent call last):
  File "test.py", line 21, in <module>
    print(datargs.parse(Args))
  File "/home/brent/miniconda/envs/fannypack/lib/python3.8/site-packages/datargs/make.py", line 423, in parse
    return cls(**result)
TypeError: __init__() missing 1 required positional argument: 'subcommand'
```

After marking as required we get:
```
> python test.py
usage: test.py [-h] --z Z {a,b} ...
test.py: error: the following arguments are required: subcommand (positional)
```