### PR TITLE
adds `Any` as return of function `arg`

### DIFF
--- a/datargs/make.py
+++ b/datargs/make.py
@@ -546,7 +546,7 @@ def arg(
     metavar=None,
     aliases: Sequence[str] = (),
     **kwargs,
-):
+) -> Any:
     """
     Helper method to more easily add parsing-related behavior.
     Supports aliases:


### PR DESCRIPTION
Fix #25