### PR TITLE
Adds new kwarg `aliases_overrides` to `arg()` function

### DIFF
--- a/datargs/compat/__init__.py
+++ b/datargs/compat/__init__.py
@@ -77,6 +77,10 @@ class RecordField(Generic[FieldType]):
     def is_positional(self) -> bool:
         return self.metadata.get("positional", False)
 
+    @property
+    def aliases_overrides(self) -> bool:
+        return self.metadata.get("aliases_overrides", False)
+
 
 class DataField(RecordField[dataclasses.Field]):
     """

--- a/datargs/make.py
+++ b/datargs/make.py
@@ -204,7 +204,7 @@ def add_any(name: str, field: RecordField, extra: dict) -> Action:
 
 def get_option_strings(name: str, field: RecordField):
     aliases = field.metadata.get("aliases", [])
-    if field.metadata.get("aliases_overrides", False) and aliases:
+    if field.aliases_overrides and aliases:
         return aliases
     return [name, *aliases]
 
@@ -229,6 +229,8 @@ def add_default(name, field: RecordField, override: dict) -> Action:
         and (override.get("default", object()) is not None)
     ):
         override["required"] = field.is_required()
+    if field.aliases_overrides and field.metadata.get("aliases", []):
+        override['dest'] = name.removeprefix('--')
     return Action(kwargs=override, args=get_option_strings(name, field))
 
 

--- a/datargs/make.py
+++ b/datargs/make.py
@@ -203,11 +203,14 @@ def add_any(name: str, field: RecordField, extra: dict) -> Action:
 
 
 def get_option_strings(name: str, field: RecordField):
-    return [name, *field.metadata.get("aliases", [])]
+    aliases = field.metadata.get("aliases", [])
+    if field.metadata.get("aliases_overrides", False) and aliases:
+        return aliases
+    return [name, *aliases]
 
 
 def common_kwargs(field: RecordField):
-    return {"type": field.type, **subdict(field.metadata, ["aliases", "positional"])}
+    return {"type": field.type, **subdict(field.metadata, ["aliases", "positional", "aliases_overrides"])}
 
 
 def subdict(dct, remove_keys):
@@ -570,6 +573,7 @@ def arg(
     help=None,
     metavar=None,
     aliases: Sequence[str] = (),
+    aliases_overrides: bool = False,
     **kwargs,
 ) -> Any:
     """
@@ -603,6 +607,7 @@ def arg(
                 metavar=metavar,
                 aliases=aliases,
                 positional=positional,
+                aliases_overrides=aliases_overrides
             )
         ),
         default=default,

--- a/datargs/make.py
+++ b/datargs/make.py
@@ -575,7 +575,7 @@ def arg(
     help=None,
     metavar=None,
     aliases: Sequence[str] = (),
-    aliases_overrides: bool = False,
+    aliases_overrides: bool = True,
     **kwargs,
 ) -> Any:
     """


### PR DESCRIPTION
Hello!

This is a proposal to achieve #27 .

Adds a new kwarg `aliases_overrides: bool` to `arg()` function

This options makes the command line use only the provided aliases and prevent it from using the field name as flag.

Example:

```python
from dataclasses import dataclass
from datargs import arg, parse

@dataclass
class Args:
    name: str = arg(aliases=["-u", "--user-name"], aliases_overrides=True)
    file: str = arg(aliases=["-f", "--file-path"], aliases_overrides=True)

parse(Args, args=['-h'])
```

Output of the above code:
```
usage: script.py [-h] -u USER_NAME -f FILE_PATH        

options:
  -h, --help            show this help message and exit
  -u USER_NAME, --user-name USER_NAME
  -f FILE_PATH, --file-path FILE_PATH
```
But parsing the parameters produces the correct NameSpace:
```python
print(parse(Args, args=['--user-name','john','--file-path','./text.txt']))
```
Output:
```
Args(name='john', file='./text.txt')
```
Some notes:
- This option could be added to the `argsclass` decorator, to make it be parsed it to all `args` at once.
- I made it the default (`aliases_overrides=True`) in the last commit, to prevent declare it when we use alias. If you do not agree, I can revert the commit. If you agree, I'm glad to change the documentation to match this behaviour.